### PR TITLE
Add pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+    -   id: check-added-large-files
+
+-   repo: https://github.com/hhatto/autopep8
+    rev: v2.3.0
+    hooks:
+    -   id: autopep8
+        args: [--in-place]
+
+-   repo: https://github.com/pycqa/flake8
+    rev: 7.2.0
+    hooks:
+    -   id: flake8
+        args: []
+
+-   repo: https://github.com/PyCQA/bandit
+    rev: 1.8.3
+    hooks:
+    -   id: bandit
+        args: ["-x", "./venv"]

--- a/paper_handling/paper_metadata_retriever.py
+++ b/paper_handling/paper_metadata_retriever.py
@@ -30,7 +30,7 @@ def get_mulitple_topic_works_titles(works):
     """
     works: array of Work objects arrays, each Work sub array corresponds to a different topic
     """
-    titles = []
+    titles = []  # bad inline comment
     for topic_work in works:
         titles.extend(get_works_titles(topic_work))
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ langchain_openai
 langchain_core
 pandas
 python-dotenv
+pre-commit


### PR DESCRIPTION
This MR adds pre-commit hooks so that upon commits, security, formatting and syntax are checked on a local level and you avoid rerunning CI/CD pipeline with multiple fails.

Closes #10 