### PR TITLE
Remove second call of loadProjectOverviewData

### DIFF
--- a/llm/Prompts.py
+++ b/llm/Prompts.py
@@ -14,6 +14,8 @@ system_prompt = SystemMessage(content="""
   Do not make up paper names that are not returned by tool calls. In that case say that you could not
   find any papers.
 
+  You do not talk directly to the user, you only send a JSON to the frontend.
+
   Return your recommendations in a JSON with the following fields:
     -message: A message to the user describing how these recommendations may help their research.
     -papers: A list of papers associated with the recommendations. This field has following subfields
@@ -24,7 +26,6 @@ system_prompt = SystemMessage(content="""
 
     Example:
     {
-        "message" : "These papers may help your research in the fields XYZ because ABC",
         "papers" : {
             {
                 "title" : "XYZ",

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -123,8 +123,4 @@ document.addEventListener('DOMContentLoaded', () => {
 
     handleRouting();
 
-    if (window.location.pathname.startsWith('/project/')) {
-        const projectId = window.location.pathname.split('/').pop();
-        loadProjectOverviewData(projectId);
-    }
 });


### PR DESCRIPTION
## Description

Remove second call to /recommendations endpoint by removing second call to loadProjectOverviewData

Fixes CAP-2

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix


## How Has This Been Tested?

Run the application and check that there is only one POST request to the backend 

## Reviewers

@AndresDChB 
