### PR TITLE
Front-end sends now project description to /recommendations endpoints

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -57,7 +57,7 @@ document.addEventListener('DOMContentLoaded', () => {
         if (document.title && titleDisplay) document.title = `Project: ${projectData.title}`;
 
         if (recommendationsContainer) {
-            fetchRecommendations(projectData.title, projectData.description)
+            fetchRecommendations(projectData.description)
                 .then(recommendations => {
                     renderRecommendations(recommendations, recommendationsContainer);
                 })


### PR DESCRIPTION
## Description

The front-end has sent until now just the project title instead of the project description.
The function fetchRecommendations was called with two arguments (projectData.title and projectData.description)
In JavaScript, if a function has in the signature just one paramater but is called with two arguments, it automatically takes just the first one. Now it takes only the project description instead of the title.

Fixes CAP-2

## Type of change

- [ ] Bug fix


## How Has This Been Tested?

Start and the application and ensure that the LLM agent was given the description instead of the title.

## Reviewers

@AndresDChB 
