### PR TITLE
Add/agent paper quality check

### DIFF
--- a/llm/Prompts.py
+++ b/llm/Prompts.py
@@ -41,3 +41,16 @@ system_prompt = SystemMessage(content="""
         }
     }
   """)
+
+quality_check_decision_prompt = SystemMessage(content="""
+You are an intelligent research assistant. Based on the similarity scores {scores}
+and the metadata for the papers {metadata}, decide what the agent should do next.
+
+Options:
+- "accept": the papers are relevant.
+- "retry_broaden": too few results, try expanding the search.
+- "reformulate_query": results are off-topic or unrelated.
+- "lower_threshold": close matches, but filtered out due to high threshold.
+
+Respond with one of the options only.
+""")

--- a/llm/Prompts.py
+++ b/llm/Prompts.py
@@ -6,19 +6,32 @@ Specifically, I'm interested in enhancing exploration-exploitation trade-offs an
 efficiency through GPU acceleration for large-scale experiments.
 """
 
+#user_message_two = """
+#I’m studying the integration of wearable biosensors with real-time health monitoring systems. I’m especially 
+#interested in energy-efficient data transmission techniques and how machine learning can be used to predict 
+#cardiovascular anomalies from sensor streams.
+#"""
+
+#user_message_two_keywords = [
+#    "Wearable Biosensors",
+#    "Real-Time Health Monitoring",
+#    "Energy-Efficient Data Transmission",
+#    "Cardiovascular Diseases",
+#    "Machine Learning"
+#]
+
 user_message_two = """
-I’m studying the integration of wearable biosensors with real-time health monitoring systems. I’m especially 
-interested in energy-efficient data transmission techniques and how machine learning can be used to predict 
-cardiovascular anomalies from sensor streams.
+I’m investigating scalable machine learning methods for real-time decision-making in high-dimensional environments. 
+I’m particularly interested in how approximate Bayesian optimization techniques and GPU acceleration can enhance 
+performance in classification and control tasks.
 """
 
 user_message_two_keywords = [
-    "Wearable Biosensors",
-    "Real-Time Health Monitoring",
-    "Energy-Efficient Data Transmission",
-    "Cardiovascular Diseases",
-    "Machine Learning"
+    "Bayesian optimization",
+    "Machine learning",
+    "GPU computing"
 ]
+
 
 user_message_three = """
 I’m exploring the role of ocean-atmosphere coupling in long-term climate variability. Specifically, I want to 

--- a/llm/Prompts.py
+++ b/llm/Prompts.py
@@ -12,16 +12,40 @@ interested in energy-efficient data transmission techniques and how machine lear
 cardiovascular anomalies from sensor streams.
 """
 
+user_message_two_keywords = [
+    "Wearable Biosensors",
+    "Real-Time Health Monitoring",
+    "Energy-Efficient Data Transmission",
+    "Cardiovascular Diseases",
+    "Machine Learning"
+]
+
 user_message_three = """
 I’m exploring the role of ocean-atmosphere coupling in long-term climate variability. Specifically, I want to 
 understand how El Niño patterns interact with polar jet streams and what models are most accurate for decadal-scale 
 prediction.
 """
 
+user_message_three_keywords = [
+    "Ocean-Atmosphere Interaction",
+    "El Niño-Southern Oscillation",
+    "Jet Streams",
+    "Climate Models",
+    "Decadal Climate Variability"
+]
+
 user_message_four = """
 I’m researching how natural language processing can support legal compliance monitoring in multinational corporations. 
 My focus is on multilingual document classification and extracting obligations from contracts across EU jurisdictions.
 """
+
+user_message_four_keywords = [
+    "Natural Language Processing",
+    "Legal Compliance",
+    "Multilingual Text Classification",
+    "Contract Analysis",
+    "European Union Law"
+]
 
 # This is supposed to be a poor query to test the agents ability to reformulate queries
 user_message_five = """
@@ -29,11 +53,27 @@ I want to learn about technology and how it’s changing stuff in the world. May
 people are talking about?”
 """
 
+user_message_five_keywords = [
+    "Technology",
+    "AI stuff",
+    "Cool inventions",
+    "Future trends",
+    "World changes"
+]
+
 user_message_six = """
 I’m looking for papers that compare the performance of the Sparse Spectrum Gaussian Process Bandit algorithm against 
 the Thompson Sampling baseline using CUDA-accelerated simulations on the MNIST dataset, specifically for the 7 vs. 9 
 digit classification task.
 """
+
+user_message_six_keywords = [
+    "Gaussian processes",
+    "Thompson sampling",
+    "Bayesian optimization",
+    "CUDA",
+    "Digit classification"
+]
 
 system_prompt = SystemMessage(content="""
   You are an expert assistant helping scientific researchers stay up-to-date with the latest literature.

--- a/llm/Prompts.py
+++ b/llm/Prompts.py
@@ -6,6 +6,29 @@ Specifically, I'm interested in enhancing exploration-exploitation trade-offs an
 efficiency through GPU acceleration for large-scale experiments.
 """
 
+user_message_two = """
+I’m studying the integration of wearable biosensors with real-time health monitoring systems. I’m especially 
+interested in energy-efficient data transmission techniques and how machine learning can be used to predict 
+cardiovascular anomalies from sensor streams.
+"""
+
+user_message_three = """
+I’m exploring the role of ocean-atmosphere coupling in long-term climate variability. Specifically, I want to 
+understand how El Niño patterns interact with polar jet streams and what models are most accurate for decadal-scale 
+prediction.
+"""
+
+user_message_four = """
+I’m researching how natural language processing can support legal compliance monitoring in multinational corporations. 
+My focus is on multilingual document classification and extracting obligations from contracts across EU jurisdictions.
+"""
+
+# This is supposed to be a poor query to test the agents ability to reformulate queries
+user_message_five = """
+I want to learn about technology and how it’s changing stuff in the world. Maybe also with AI. What are the big things 
+people are talking about?”
+"""
+
 system_prompt = SystemMessage(content="""
   You are an expert assistant helping scientific researchers stay up-to-date with the latest literature.
   Your task is to analyze the user's research interests and use your available tools to query papers titles

--- a/llm/Prompts.py
+++ b/llm/Prompts.py
@@ -29,6 +29,12 @@ I want to learn about technology and how it’s changing stuff in the world. May
 people are talking about?”
 """
 
+user_message_six = """
+I’m looking for papers that compare the performance of the Sparse Spectrum Gaussian Process Bandit algorithm against 
+the Thompson Sampling baseline using CUDA-accelerated simulations on the MNIST dataset, specifically for the 7 vs. 9 
+digit classification task.
+"""
+
 system_prompt = SystemMessage(content="""
   You are an expert assistant helping scientific researchers stay up-to-date with the latest literature.
   Your task is to analyze the user's research interests and use your available tools to query papers titles

--- a/llm/tools/paper_handling_tools.py
+++ b/llm/tools/paper_handling_tools.py
@@ -1,7 +1,7 @@
 from typing import Any
 import json
 from llm.LLMDefinition import LLM 
-from llm.Prompts import user_message
+from llm.Prompts import user_message, user_message_two, user_message_four, user_message_three, user_message_five
 
 from paper_handling.paper_handler import fetch_works_multiple_queries
 
@@ -149,7 +149,7 @@ def retry_with_modified_parameters(action: str, current_query: str, attempt: int
         raise ValueError(f"Unknown action: {action}")
     
 
-def quality_control_loop(retrieved_papers: list[dict], current_query: str, attempt: int = 0) -> list[dict]:
+def quality_control_loop(retrieved_papers: list[dict], current_query: str, attempt: int = 0):
     """
     Wraps steps 5–7 together.
     - Calls `check_relevance_threshold`
@@ -161,7 +161,7 @@ def quality_control_loop(retrieved_papers: list[dict], current_query: str, attem
 
     if is_satisfactory:
         print(f"Attempt {attempt}: Papers are satisfactory.")
-        return retrieved_papers 
+        return None
 
     action = decide_next_action(retrieved_papers, current_query)
     print(f"Attempt {attempt}: Decided action - {action}")
@@ -169,7 +169,7 @@ def quality_control_loop(retrieved_papers: list[dict], current_query: str, attem
     next_query = retry_with_modified_parameters(action, current_query, attempt)
     
     if next_query == current_query:  # If no change needed, return the papers
-        return retrieved_papers
+        return None
 
     # TODO: REFETCH PAPERS WITH THE NEW QUERY
     new_retrieved_papers = []
@@ -246,5 +246,24 @@ if __name__ == "__main__":
     """
     )
 
-    action = decide_next_action(papers_with_metadata, user_message)
-    print("Agent decision:", action)
+    quality_control_loop(papers_with_metadata, user_message)
+
+    # Test case 2: For now there is no similarity score, so the first method will not be triggered
+
+    query_two_papers = fetch_works_multiple_queries(queries=[user_message_two])
+    quality_control_loop(query_two_papers, user_message_two)
+
+    # Test case 3: For now there is no similarity score, so the first method will not be triggered
+
+    query_three_papers = fetch_works_multiple_queries(queries=[user_message_three])
+    quality_control_loop(query_three_papers, user_message_three)
+    
+    # Test case 4: For now there is no similarity score, so the first method will not be triggered
+
+    query_four_papers = fetch_works_multiple_queries(queries=[user_message_four])
+    quality_control_loop(query_four_papers, user_message_four)
+
+    # Test case 5: This tests a defect query that should be reformulated
+
+    query_five_papers = fetch_works_multiple_queries(queries=[user_message_five])
+    quality_control_loop(query_five_papers, user_message_five)

--- a/llm/tools/paper_handling_tools.py
+++ b/llm/tools/paper_handling_tools.py
@@ -44,3 +44,105 @@ def _get_link(work):
         else:
             link = "#"
     return link
+
+
+def check_relevance_threshold(papers_with_relevance_scores: list[dict], threshold: float) -> bool:
+    """
+    Step 5: Checks if the similarity scores in the list of papers meet the specified threshold.
+    Returns True if results are satisfactory, False otherwise.
+
+    Args:
+        papers_with_relevance_scores: A list of dictionaries where each dict represents a paper and includes a 'similarity_score' key.
+        threshold: The minimum similarity score required for a paper to be considered relevant.
+
+    Returns:
+        True if all relevant papers meet the threshold (uses top 3 if available), otherwise False.
+    """
+    top_papers = papers_with_relevance_scores[:3] if len(papers_with_relevance_scores) > 3 else papers_with_relevance_scores
+    return all(paper.get("similarity_score", 0.0) >= threshold for paper in top_papers)
+
+
+def decide_next_action(papers_with_metadata: list[dict]) -> str:
+    """
+    Step 6: Agent logic to decide what to do next if results are not satisfactory.
+    Returns one of: "retry_broaden", "reformulate_query", "lower_threshold", or "accept".
+    """
+
+    formatted_metadata = "\n\n".join(
+        f"""Paper {i+1}:
+            - Title: {paper.get("title", "N/A")}
+            - Similarity Score: {paper.get("similarity_score", "N/A")}
+            - Citation Count: {paper.get("cited_by_count", "N/A")}
+            - FWCI: {paper.get("fwci", "N/A")}
+            - Abstract: {paper.get("abstract", "N/A")}"""
+        for i, paper in enumerate(papers_with_metadata)
+    )
+
+    prompt = f"""
+    You are an intelligent research assistant responsible for evaluating a set of research papers returned from a query.
+
+    For each paper, you have access to metadata such as:
+    - similarity score (relevance to the original query),
+    - citation count,
+    - field-weighted citation impact (FWCI),
+    - title,
+    - abstract.
+
+    Your goal is to assess whether the current set of results is satisfactory, or whether another action should be taken.
+
+    Please choose **one** of the following actions based on the quality and relevance of the papers:
+    - "accept": The papers are relevant and high-quality.
+    - "retry_broaden": The papers are too narrow or too few, try a broader version of the current query.
+    - "reformulate_query": The current query is off, and should be reformulated to better capture the user intent.
+    - "lower_threshold": The threshold for similarity or quality might be too high, and lowering it could yield more useful results.
+
+    You may consider papers satisfactory if:
+    - Most have high similarity scores (e.g. > 0.7),
+    - They include recent and well-cited research,
+    - They align well with the query topic as indicated by abstract and title.
+
+    Now decide based on the following paper metadata:
+
+    {formatted_metadata}
+    """
+
+    # You would then feed `prompt` into your LLM to get the agent’s decision
+    return prompt  # Replace this line with LLM completion call if integrating with an agent
+
+
+
+def retry_with_modified_parameters(action: str, current_query: str, attempt: int) -> str:
+    """
+    Step 7: Based on the agent’s decision, generates the next query or parameters.
+    References the output of `decide_next_action`.
+    """
+
+    if action == "accept":
+        return current_query  # No change needed, accept the current query
+
+    elif action == "retry_broaden":
+        # Broaden the query by adding more general terms or synonyms
+        broadened_query = f"{current_query} broadening search terms"
+        return broadened_query
+
+    elif action == "reformulate_query":
+        # Reformulate the query to better capture user intent
+        reformulated_query = f"Reformulated: {current_query} with better keywords"
+        return reformulated_query
+
+    elif action == "lower_threshold":
+        # Lower the threshold for relevance scores
+        new_threshold = 0.5  # Example of lowering the threshold
+        return f"{current_query} with threshold {new_threshold}"
+
+    else:
+        raise ValueError(f"Unknown action: {action}")
+    
+
+def quality_control_loop(paper_candidates: list[dict], current_query: str, attempt: int = 0) -> list[dict]:
+    """
+    Wraps steps 5–7 together.
+    - Calls `check_relevance_threshold`
+    - If False, calls `decide_next_action`
+    - Then `retry_with_modified_parameters` and loops if necessary
+    """

--- a/llm/tools/paper_handling_tools.py
+++ b/llm/tools/paper_handling_tools.py
@@ -273,27 +273,27 @@ if __name__ == "__main__":
 
     print("\n========== Test Case 2: No similarity scores (should invoke agent) ==========")
     query_two_papers = fetch_works_multiple_queries(queries=[prompts.user_message_two_keywords])
-    quality_control_loop(query_two_papers, prompts.user_message_two)
+    print(query_two_papers)
+    #quality_control_loop(query_two_papers, prompts.user_message_two)
 
     print("\n========== Test Case 3: No similarity scores (should invoke agent) ==========")
-    query_three_papers = fetch_works_multiple_queries(queries=[prompts.user_message_three_keywords])
-    quality_control_loop(query_three_papers, prompts.user_message_three)
+    #query_three_papers = fetch_works_multiple_queries(queries=[prompts.user_message_three_keywords])
+    #quality_control_loop(query_three_papers, prompts.user_message_three)
 
     print("\n========== Test Case 4: No similarity scores (should invoke agent) ==========")
-    query_four_papers = fetch_works_multiple_queries(queries=[prompts.user_message_four_keywords])
-    quality_control_loop(query_four_papers, prompts.user_message_four)
+    #query_four_papers = fetch_works_multiple_queries(queries=[prompts.user_message_four_keywords])
+    #quality_control_loop(query_four_papers, prompts.user_message_four)
 
     print("\n========== Test Case 5: Defective query – agent should suggest reformulation ==========")
-    query_five_papers = fetch_works_multiple_queries(queries=[prompts.user_message_five_keywords])
-    print(f"Retrieved {len(query_five_papers)} papers for Test Case 5")
-    quality_control_loop(query_five_papers, prompts.user_message_five)
+    #query_five_papers = fetch_works_multiple_queries(queries=[prompts.user_message_five_keywords])
+    #quality_control_loop(query_five_papers, prompts.user_message_five)
 
     print("\n========== Test Case 6: Overly narrow query – agent should suggest broadening ==========")
-    query_six_papers = fetch_works_multiple_queries(queries=[prompts.user_message_six_keywords])
-    quality_control_loop(query_six_papers, prompts.user_message_six)
+    #query_six_papers = fetch_works_multiple_queries(queries=[prompts.user_message_six_keywords])
+    #quality_control_loop(query_six_papers, prompts.user_message_six)
 
     print("\n========== Test Case 8: Non-sensical query – agent should trigger correction ==========")
-    query_eight_papers = fetch_works_multiple_queries(queries=["Hello"])
-    quality_control_loop(query_eight_papers, "Hello")
+    #query_eight_papers = fetch_works_multiple_queries(queries=["Hello"])
+    #quality_control_loop(query_eight_papers, "Hello")
 
     

--- a/llm/tools/paper_handling_tools.py
+++ b/llm/tools/paper_handling_tools.py
@@ -108,7 +108,7 @@ def decide_next_action(papers_with_metadata: list[dict], user_query: str) -> str
 
     Respond with a JSON object with the following structure:
     {{
-    "action": "...",  // one of: accept, retry_broaden, reformulate_query, lower_threshold
+    "action": "...",  // one of: accept, retry_broaden, reformulate_query
     "reason": "..."   // brief explanation why the action was chosen (max 2 sentences)
     }}
     Only output the JSON object. Do not include any other text or formatting.
@@ -124,7 +124,7 @@ def decide_next_action(papers_with_metadata: list[dict], user_query: str) -> str
 
     Respond with a JSON object with the following structure:
     {{
-    "action": "...",  // one of: accept, retry_broaden, reformulate_query, lower_threshold
+    "action": "...",  // one of: accept, retry_broaden, reformulate_query
     "reason": "..."   // brief explanation why the action was chosen (max 2 sentences)
     }}
     Only output the JSON object. Do not include any other text or formatting.
@@ -183,7 +183,7 @@ def quality_control_loop(retrieved_papers: list[dict], current_query: str, attem
     is_satisfactory = check_relevance_threshold(retrieved_papers, threshold, min_papers=3)
 
     if is_satisfactory:
-        print(f"Attempt {attempt}: Papers are satisfactory.")
+        print(f"Attempt {attempt}: Papers are satisfactory (accepted by similarity score, no agent action).")
         return None
 
     print(f"Number of retrieved papers: {len(retrieved_papers)}")
@@ -263,37 +263,66 @@ if __name__ == "__main__":
         ],
         "landing_page_url": "https://doi.org/10.21203/rs.3.rs-6763537/v1",
         "pdf_url": null
+    },
+    {
+    "id": "https://openalex.org/W1234567890",
+    "title": "Optimizing Clinical Workflow Integration of LLM-Based Decision Support Systems",
+    "abstract": "Recent advances in large language models (LLMs) have opened new frontiers for decision support in clinical environments. This paper presents a framework for aligning LLM capabilities with routine physician tasks by incorporating real-time feedback, structured knowledge grounding, and task-specific fine-tuning. We evaluate our approach on a multi-specialty dataset containing 75,000 structured clinical interactions and introduce MedAlignBench, a benchmark suite simulating realistic use cases across diagnostics, prescription drafting, and medical documentation. Results show significant improvements in clinician satisfaction and response accuracy, especially when models are tailored to workflow-specific prompts.",
+    "authors": "Alicia Zhang, David Patel, Rana Al-Hassan, Thomas L. Lee",
+    "publication_date": "2025-05-18",
+    "fwci": 1.42,
+    "citation_normalized_percentile": 82.3,
+    "cited_by_count": 12,
+    "counts_by_year": [{"year": 2025, "count": 12}],
+    "similarity_score": 0.79,
+    "topics": [
+        {
+            "topic": "Scientific Computing and Data Management",
+            "score": 0.89,
+            "subfields": ["Healthcare Informatics"],
+            "fields": ["Decision Sciences"],
+            "domains": ["Social Sciences"]
+        },
+        {
+            "topic": "Large Language Models in Healthcare",
+            "score": 0.85,
+            "subfields": ["Medical AI"],
+            "fields": ["Computer Science"],
+            "domains": ["Health Sciences"]
         }
+    ],
+    "landing_page_url": "https://doi.org/10.1234/medalign.2025.005",
+    "pdf_url": "https://arxiv.org/pdf/medalign.2025.005.pdf"
+    }
     ]
     """
     )
 
-    #print("\n========== Test Case 1: Query with precomputed similarity scores ==========")
-    #quality_control_loop(papers_with_metadata, user_message)
+    print("\n========== Test Case 1: Query with precomputed similarity scores ==========")
+    quality_control_loop(papers_with_metadata, prompts.user_message)
 
     print("\n========== Test Case 2: No similarity scores (should invoke agent) ==========")
     query_two_papers = fetch_works_multiple_queries(queries=[prompts.user_message_two_keywords])
-    print(query_two_papers)
-    #quality_control_loop(query_two_papers, prompts.user_message_two)
+    quality_control_loop(query_two_papers, prompts.user_message_two)
 
     print("\n========== Test Case 3: No similarity scores (should invoke agent) ==========")
-    #query_three_papers = fetch_works_multiple_queries(queries=[prompts.user_message_three_keywords])
-    #quality_control_loop(query_three_papers, prompts.user_message_three)
+    query_three_papers = fetch_works_multiple_queries(queries=[prompts.user_message_three_keywords])
+    quality_control_loop(query_three_papers, prompts.user_message_three)
 
     print("\n========== Test Case 4: No similarity scores (should invoke agent) ==========")
-    #query_four_papers = fetch_works_multiple_queries(queries=[prompts.user_message_four_keywords])
-    #quality_control_loop(query_four_papers, prompts.user_message_four)
+    query_four_papers = fetch_works_multiple_queries(queries=[prompts.user_message_four_keywords])
+    quality_control_loop(query_four_papers, prompts.user_message_four)
 
     print("\n========== Test Case 5: Defective query – agent should suggest reformulation ==========")
-    #query_five_papers = fetch_works_multiple_queries(queries=[prompts.user_message_five_keywords])
-    #quality_control_loop(query_five_papers, prompts.user_message_five)
+    query_five_papers = fetch_works_multiple_queries(queries=[prompts.user_message_five_keywords])
+    quality_control_loop(query_five_papers, prompts.user_message_five)
 
     print("\n========== Test Case 6: Overly narrow query – agent should suggest broadening ==========")
-    #query_six_papers = fetch_works_multiple_queries(queries=[prompts.user_message_six_keywords])
-    #quality_control_loop(query_six_papers, prompts.user_message_six)
+    query_six_papers = fetch_works_multiple_queries(queries=[prompts.user_message_six_keywords])
+    quality_control_loop(query_six_papers, prompts.user_message_six)
 
     print("\n========== Test Case 8: Non-sensical query – agent should trigger correction ==========")
-    #query_eight_papers = fetch_works_multiple_queries(queries=["Hello"])
-    #quality_control_loop(query_eight_papers, "Hello")
+    query_eight_papers = fetch_works_multiple_queries(queries=["Hello"])
+    quality_control_loop(query_eight_papers, "Hello")
 
     

--- a/paper_handling/paper_handler.py
+++ b/paper_handling/paper_handler.py
@@ -24,7 +24,7 @@ def _fetch_works_single_query(query, from_publication_date=None):
         )
         if from_publication_date:
             works_query = works_query.filter(from_publication_date=from_publication_date)
-        works = works_query.get(per_page=1)
+        works = works_query.get(per_page=5)
     except Exception as e:
         print(f"Error fetching works for query '{query}': {e}")
         return []

--- a/paper_handling/paper_handler.py
+++ b/paper_handling/paper_handler.py
@@ -16,7 +16,8 @@ def _fetch_works_single_query(query, from_publication_date=None):
         works_query = (
             Works()
             .select(
-                "id,title,abstract_inverted_index,authorships,publication_date,primary_location"
+                "id,title,abstract_inverted_index,authorships,publication_date,primary_location,citation_normalized_percentile, " \
+                "fwci,cited_by_count,counts_by_year,topics"
             )
             .search(query)
             .sort(relevance_score="desc")
@@ -55,12 +56,24 @@ def _fetch_works_single_query(query, from_publication_date=None):
 
             publication_date = work.get("publication_date")
 
+            citation_normalized_percentile = work.get("citation_normalized_percentile")
+            fwci = work.get("fwci")
+            cited_by_count = work.get("cited_by_count")
+            counts_by_year = work.get("counts_by_year")
+
+            topics = clean_topics_field(work.get("topics"))
+
             results.append({
                 "id": work_id,
                 "title": title,
                 "abstract": abstract,
                 "authors": authors,
                 "publication_date": publication_date,
+                "fwci": fwci,
+                "citation_normalized_percentile": citation_normalized_percentile,
+                "cited_by_count": cited_by_count,
+                "counts_by_year": counts_by_year,
+                "topics": topics,
                 "landing_page_url": landing_page_url,
                 "pdf_url": pdf_url
             })
@@ -100,6 +113,38 @@ def fetch_works_multiple_queries(queries, from_publication_date=None):
         except Exception as e:
             print(f"Error fetching works for query '{query}': {e}")
     return all_results
+
+
+def clean_topics_field(topics: list[dict]) -> list[dict]:
+    """
+    Cleans a list of OpenAlex topic dictionaries for prompt-efficient use by an agent.
+    Handles multiple subfields/fields/domains per topic if they exist as lists.
+
+    Args:
+        topics (list[dict]): Original list of topic entries from OpenAlex.
+
+    Returns:
+        list[dict]: Cleaned list of topic information.
+    """
+    def get_names(entry):
+        if isinstance(entry, list):
+            return [e.get("display_name") for e in entry if "display_name" in e]
+        elif isinstance(entry, dict):
+            return [entry.get("display_name")]
+        else:
+            return []
+
+    cleaned = []
+    for topic in topics:
+        cleaned_entry = {
+            "topic": topic.get("display_name"),
+            "score": topic.get("score"),
+            "subfields": get_names(topic.get("subfield")),
+            "fields": get_names(topic.get("field")),
+            "domains": get_names(topic.get("domain"))
+        }
+        cleaned.append(cleaned_entry)
+    return cleaned
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

In this issue I have build a workflow for the agent to review the retrieved papers from OpenAlex before any further steps to assess whether the retrieval yielded a sufficient quality of papers based on the users initial query. For that the agent looks at relevant metadata from OpenAlex, alongside the actual paper text such as Citation_score, FWCI (field weighted citation impact), citation normalized by percentile, and more.For now the agent is not taking any action but it is just printed out what decision the agent has made. Also, the tool is not yet integrated in the agent workflow but rather is using a standalone LLM instance. The tools will be added to the agents functionality in the next PR. The whole program logic can is displayed in detail in the attached graphic (icons or flows that are not coloured are things that are not yet added and will be added in the next PR).

![Screenshot at Jun 04 18-51-33](https://github.com/user-attachments/assets/dd966cf4-9e83-4f8f-8a5a-b3e18ec863ec)

Fixes # (issue)

Added new feature (https://www.notion.so/Agentic-Paper-Quality-Check-206886100416805abc03ec061192fa18?source=copy_link)

Please delete options that are not relevant.

- [X] New feature
- [X] Refactor (code cleanup, performance improvements, etc.)

## How Has This Been Tested?

Created multiple test cases with user queries and manually created search keywords to retrieve papers and let the agent analyse them. There are some test cases that need a slight explanation:

- [ ] Test 1: Here we test the first functionality which decides that the papers are valid by similarity score (e.g. embedding and comparing vector of paper and user query). As the embedding is not yet included it was added manually. 
- [ ] Test 5: Bad query - Agent should suggest altering the query
- [ ] Test 6: Overly narrow / specific query - Agent should suggest altering the query
- [ ] Test 7: Bad query - Agent should suggest altering the query

## Reviewers

Navigate into the Capstone project folder and run `python -m llm.tools.paper_handling_tools` (this is needed as the test rely in imports outside the paper_handling_tools.py file and running the main that contains the test cases only locally, will not recognise the imports.

Go through the imports confirm the output and reasoning of the agents, test cases 5,6,7 should not pass. The earlier ones can pass but dont have to be. If you want add new test cases by creating a new sample query plus keywords and see if the agent arrives at the right conclusion! (for that add a new `user_message_eight` and `user_message_eight_keywords` to the `Prompts.py` file and use them in the main method in `paper_handling_tools.py`

@AndresDChB 
reviewers here
