### PR TITLE
Chroma now has persistent storage

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     ports:
       - "8000:8000"
     volumes:
-      - chroma_data:/chroma/.chroma
+      - chroma_data:/data
     environment:
       - IS_PERSISTENT=TRUE
     restart: unless-stopped


### PR DESCRIPTION
Docker-compose had the incorrect chroma persistency path 



## Type of change

Please delete options that are not relevant.

- [x] Bug fix

## How Has This Been Tested?

1 Create code to count papers (it's in another branch: show-thoughts).

2 Run docker compose up

3 Count papers before ingesting papers: should be 0

4 Make chroma ingest data with chroma_ingest_paper.py

5 Count papers after ingesting papers: should be higher than 0

6 Docker compose down

7 Docker compose up

8 Count papers in chroma should be the same number as in step 5.

## Reviewers

@nulladiti, @yawri 