### PR TITLE
Add paper upload UI.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -179,3 +179,120 @@ h1 {
     white-space: pre-wrap;
     word-break: break-all;
 }
+
+.upload-description {
+    font-size: 14px;
+    color: #6c757d;
+    margin-bottom: 12px;
+    margin-top: -4px;
+}
+
+.upload-area {
+    border: 2px dashed #ced4da;
+    border-radius: 8px;
+    padding: 32px 20px;
+    text-align: center;
+    background-color: #f8f9fa;
+    transition: all 0.2s ease;
+    cursor: pointer;
+}
+
+.upload-area:hover {
+    border-color: #007bff;
+    background-color: #f0f8ff;
+}
+
+.upload-area.dragover {
+    border-color: #007bff;
+    background-color: #e3f2fd;
+}
+
+.upload-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+}
+
+.upload-icon {
+    font-size: 48px;
+    opacity: 0.5;
+}
+
+.upload-text {
+    font-size: 16px;
+    color: #495057;
+    margin: 0;
+}
+
+.upload-link {
+    color: #007bff;
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.upload-link:hover {
+    color: #0056b3;
+}
+
+.upload-hint {
+    font-size: 12px;
+    color: #6c757d;
+    margin: 0;
+}
+
+.file-info {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 16px;
+    border: 1px solid #e0e0e0;
+    border-radius: 8px;
+    background-color: #f8f9fa;
+}
+
+.file-details {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.file-icon {
+    font-size: 24px;
+}
+
+.file-name-size {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.file-name {
+    font-weight: 500;
+    color: #343a40;
+    font-size: 14px;
+}
+
+.file-size {
+    font-size: 12px;
+    color: #6c757d;
+}
+
+.btn-remove {
+    padding: 6px 12px;
+    background-color: #dc3545;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    font-size: 12px;
+    cursor: pointer;
+    transition: background-color 0.2s ease;
+}
+
+.btn-remove:hover {
+    background-color: #c82333;
+}
+
+.btn-remove:active {
+    transform: scale(0.98);
+}

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -3,7 +3,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const path = window.location.pathname;
 
         if (path === '/create-project') {
-           // Do nothing in this case for now
+           setupPDFUpload();
         } else if (path.startsWith('/project/')) {
             const projectId = path.split('/').pop();
             loadProjectOverviewData(projectId);
@@ -33,6 +33,86 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         }
     };
+
+    function setupPDFUpload() {
+        const uploadArea = document.getElementById('uploadArea');
+        const fileInput = document.getElementById('paperUpload');
+        const fileInfo = document.getElementById('fileInfo');
+        const fileName = document.getElementById('fileName');
+        const fileSize = document.getElementById('fileSize');
+        const removeBtn = document.getElementById('removeFile');
+        if (!uploadArea || !fileInput) return;
+
+        uploadArea.addEventListener('click', () => {
+            fileInput.click();
+        });
+
+        uploadArea.addEventListener('dragover', (e) => {
+            e.preventDefault();
+            uploadArea.classList.add('dragover');
+        });
+
+        uploadArea.addEventListener('dragleave', (e) => {
+            e.preventDefault();
+            uploadArea.classList.remove('dragover');
+        });
+
+        uploadArea.addEventListener('drop', (e) => {
+            e.preventDefault();
+            uploadArea.classList.remove('dragover');
+            
+            const files = e.dataTransfer.files;
+            if (files.length > 0) {
+                handleFileSelection(files[0]);
+            }
+        });
+
+        fileInput.addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            if (file) {
+                handleFileSelection(file);
+            }
+        });
+
+        removeBtn?.addEventListener('click', () => {
+            removeFile();
+        });
+
+        function handleFileSelection(file) {
+            if (file.type !== 'application/pdf') {
+                alert('Please select a PDF file only.');
+                return;
+            }
+
+            const maxSize = 50 * 1024 * 1024;
+            if (file.size > maxSize) {
+                alert('File size must be less than 50MB.');
+                return;
+            }
+
+            displayFileInfo(file);
+        }
+
+        function displayFileInfo(file) {
+            const sizeInMB = (file.size / (1024 * 1024)).toFixed(2);
+            
+            fileName.textContent = file.name;
+            fileSize.textContent = `${sizeInMB} MB`;
+            
+            uploadArea.style.display = 'none';
+            fileInfo.style.display = 'flex';
+        }
+
+        function removeFile() {
+            fileInput.value = '';
+            
+            fileInfo.style.display = 'none';
+            uploadArea.style.display = 'block';
+            
+            fileName.textContent = '';
+            fileSize.textContent = '';
+        }
+    }
 
     const loadProjectOverviewData = (projectId) => {
         // TODO: For now use localStorage for the project data

--- a/templates/create_project.html
+++ b/templates/create_project.html
@@ -18,6 +18,32 @@
                 <label for="projectDescription">Project Prompt</label>
                 <textarea id="projectDescription" name="projectDescription" rows="4" required></textarea>
             </div>
+            
+            <div class="form-group">
+                <label for="paperUpload">Upload Reference Paper (Optional)</label>
+                <p class="upload-description">Upload a PDF to enhance your project recommendations</p>
+                
+                <div id="uploadArea" class="upload-area">
+                    <div class="upload-content">
+                        <div class="upload-icon">📄</div>
+                        <p class="upload-text">Drag & drop your PDF here</p>
+                        <p class="upload-hint">Single PDF file, max 50MB</p>
+                    </div>
+                    <input type="file" id="paperUpload" accept=".pdf" style="display: none;">
+                </div>
+                
+                <div id="fileInfo" class="file-info" style="display: none;">
+                    <div class="file-details">
+                        <div class="file-icon">📄</div>
+                        <div class="file-name-size">
+                            <span id="fileName" class="file-name"></span>
+                            <span id="fileSize" class="file-size"></span>
+                        </div>
+                    </div>
+                    <button type="button" id="removeFile" class="btn-remove">Remove</button>
+                </div>
+            </div>
+            
             <button type="submit" class="btn btn-primary">Create Project</button>
         </form>
     </div>


### PR DESCRIPTION
## Description

Added a PDF upload UI component to the project creation screen. Users can now upload a single reference paper (PDF) that will be used to enhance project recommendations. The upload section is positioned below the project description field and includes:

- Drag & drop functionality for PDF files
- Click-to-browse file selection
- File validation (PDF only, max 50MB)
- File info display with name and size
- Remove uploaded file functionality
- Single file upload restriction (users cannot upload multiple PDFs)

The UI is designed to be clean and consistent with the existing project styling.

## Type of change

- [x] New feature

## How Has This Been Tested?

- [x] **Drag & Drop Testing**: Verified PDF files can be dragged and dropped onto the upload area
- [x] **File Selection Testing**: Confirmed clicking the upload area opens file browser and accepts PDF files
- [x] **File Validation Testing**: Tested that non-PDF files are rejected with appropriate error message
- [x] **File Display Testing**: Confirmed uploaded file shows name and size correctly
- [x] **Remove Functionality**: Tested that clicking "Remove" clears the file and allows new upload
- [x] **Single File Restriction**: Verified only one PDF can be uploaded at a time


## Reviewers
@SashoVihVas @Sam-rez-cardin 