### PR TITLE
Make project description view collapsible for long description

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -94,6 +94,108 @@ h1 {
     line-height: 1.6;
 }
 
+.description-wrapper {
+    position: relative;
+    overflow: hidden;
+    transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.description-content {
+    font-size: 16px;
+    color: #6c757d;
+    line-height: 1.6;
+    padding: 0;
+    overflow: hidden;
+    transition: all 0.4s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    position: relative;
+}
+
+.description-content.collapsed {
+    max-height: 9.3em; /* Approx. 5.8 lines with 1.6 line-height */
+}
+
+.description-content.expanded {
+    max-height: none;
+}
+
+.description-fade-overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 1.6em;
+    background: linear-gradient(to bottom, 
+        rgba(248, 249, 250, 0) 0%, 
+        rgba(248, 249, 250, 0.8) 70%, 
+        rgba(248, 249, 250, 1) 100%);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.description-fade-overlay.visible {
+    opacity: 1;
+}
+
+.description-controls {
+    display: flex;
+    justify-content: center;
+    margin-top: 12px;
+    opacity: 0;
+    transform: translateY(-8px);
+    transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+}
+
+.description-controls.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.expand-btn {
+    background: rgba(0, 0, 0, 0.03);
+    border: 1px solid rgba(0, 0, 0, 0.06);
+    border-radius: 16px;
+    padding: 6px 12px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    transition: all 0.2s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    font-size: 13px;
+    color: #6c757d;
+    font-weight: 500;
+}
+
+.expand-btn:hover {
+    background: rgba(0, 0, 0, 0.06);
+    border-color: rgba(0, 0, 0, 0.1);
+    color: #495057;
+    transform: translateY(-1px);
+}
+
+.expand-btn:active {
+    transform: translateY(0);
+    background: rgba(0, 0, 0, 0.08);
+}
+
+.expand-text {
+    font-size: 13px;
+    transition: all 0.2s ease;
+}
+
+.expand-icon {
+    width: 14px;
+    height: 14px;
+    transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    flex-shrink: 0;
+}
+
+.expand-btn.expanded .expand-icon {
+    transform: rotate(180deg);
+}
+
+
+
 .recommendations-section h2 {
     font-size: 22px;
     color: #343a40;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -134,7 +134,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const agentThoughtsContainer = document.getElementById('agentThoughtsContainer');
 
         if (titleDisplay) titleDisplay.textContent = projectData.title;
-        if (descriptionDisplay) descriptionDisplay.textContent = projectData.description;
+        if (descriptionDisplay) {
+            descriptionDisplay.textContent = projectData.description;
+            setupCollapsibleDescription(projectData.description);
+        }
         if (document.title && titleDisplay) document.title = `Project: ${projectData.title}`;
 
         if (recommendationsContainer && agentThoughtsContainer) {
@@ -248,6 +251,47 @@ document.addEventListener('DOMContentLoaded', () => {
             card.appendChild(descriptionEl);
             container.appendChild(card);
         });
+    }
+
+    function setupCollapsibleDescription(description) {
+        const descriptionDisplay = document.getElementById('projectDescriptionDisplay');
+        const descriptionWrapper = descriptionDisplay?.parentElement;
+        const toggleButton = document.getElementById('descriptionToggle');
+        const fadeOverlay = document.getElementById('descriptionFadeOverlay');
+        const controls = document.getElementById('descriptionControls');
+        const expandText = toggleButton?.querySelector('.expand-text');
+        
+        if (!descriptionDisplay || !descriptionWrapper || !toggleButton || !fadeOverlay || !controls || !expandText) return;
+
+        const wordCount = description.trim().split(/\s+/).length;
+
+        if (wordCount > 500) {
+            const isCollapsed = true;
+            
+            descriptionDisplay.classList.toggle('collapsed', isCollapsed);
+            descriptionDisplay.classList.toggle('expanded', !isCollapsed);
+            toggleButton.classList.toggle('expanded', !isCollapsed);
+            fadeOverlay.classList.toggle('visible', isCollapsed);
+            controls.classList.add('visible');
+            
+            expandText.textContent = isCollapsed ? 'Show full description' : 'Show less';
+            
+            toggleButton.addEventListener('click', () => {
+                const currentlyCollapsed = descriptionDisplay.classList.contains('collapsed');
+                
+                descriptionDisplay.classList.toggle('collapsed', !currentlyCollapsed);
+                descriptionDisplay.classList.toggle('expanded', currentlyCollapsed);
+                toggleButton.classList.toggle('expanded', currentlyCollapsed);
+                fadeOverlay.classList.toggle('visible', !currentlyCollapsed);
+                
+                expandText.textContent = !currentlyCollapsed ? 'Show full description' : 'Show less';
+            });
+        } else {
+            // Short description, no need to use expandable view
+            descriptionDisplay.classList.add('expanded');
+            fadeOverlay.classList.remove('visible');
+            controls.classList.remove('visible');
+        }
     }
 
     handleRouting();

--- a/templates/project_overview.html
+++ b/templates/project_overview.html
@@ -10,7 +10,20 @@
     <div class="container">
         <div class="project-header">
             <h1 id="projectTitleDisplay"></h1>
-            <p id="projectDescriptionDisplay"></p>
+            <div class="description-wrapper">
+                <div class="description-content" id="projectDescriptionDisplay">
+                    <!-- Project description will be loaded here -->
+                </div>
+                <div class="description-fade-overlay" id="descriptionFadeOverlay"></div>
+            </div>
+            <div class="description-controls" id="descriptionControls">
+                <button class="expand-btn" id="descriptionToggle">
+                    <span class="expand-text">Show more</span>
+                    <svg class="expand-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+                        <polyline points="6,9 12,15 18,9"></polyline>
+                    </svg>
+                </button>
+            </div>
         </div>
 
         <div class="agent-thoughts-section">


### PR DESCRIPTION
## Description

Added a collapsible description feature to the project overview page. The feature automatically collapses long project descriptions (>500 words) to improve readability and page layout, while providing an elegant expand/collapse mechanism for users to view the full content.

Key changes:
- Implemented collapsible description container with fade-out effect
- Added centered "Show full description" / "Show less" toggle button with smooth animations
- Applied sleek, modern design with rounded corners, subtle shadows, and cubic-bezier transitions
- Smart auto-collapse logic based on content length (>500 words collapsed by default)

## Type of change
- [x] New feature


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Manual testing with short descriptions (<100 words) - verified toggle button is hidden
- [x] Manual testing with long descriptions (>500 words) - verified auto-collapse with fade-out effect

## Reviewers

@SashoVihVas @nulladiti 