### PR TITLE
Fix incompatible langgraph version & run flask app on port 80

### DIFF
--- a/app.py
+++ b/app.py
@@ -117,4 +117,4 @@ def extract_pdf_text():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', debug=True, port=7500)  # nosec B201, B104
+    app.run(host='0.0.0.0', debug=True, port=80)  # nosec B201, B104

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
         python app.py
       "
     ports:
-      - "7500:7500"
+      - "80:80"
     volumes:
       - .:/app
     working_dir: /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ chromadb==1.0.12
 langchain-core==0.3.63
 langchain-openai==0.3.19
 langchain==0.3.25
-langgraph~=0.4.5
+langgraph==0.5.0
 openai==1.79.0
 psycopg2-binary==2.9.10
 pyalex==0.18


### PR DESCRIPTION
## Description

Run flask webapp on port 80 instead of 7500 to avoid firewall issues on the server.
Also, fix issue with incompatible langgraph version.


## Type of change
- [x] Bug fix


## How Has This Been Tested?

Run app on server and verify it is accessible.

## Reviewers

@Sam-rez-cardin 
