### PR TITLE
adjusted system prompt for agent, added capability to add parameter t…

### DIFF
--- a/llm/Prompts.py
+++ b/llm/Prompts.py
@@ -105,6 +105,8 @@ You have access to the following tools:
 
 7. update_papers — AFTER the query is validated/optimized, always call this to pull the latest papers from OpenAlex.
 8. get_best_papers — Run immediately after `update_papers` to retrieve the top-matching papers.
+    If you intend to apply filtering in the next step, always call get_best_papers with num_candidates=100 to ensure a large enough sample size for filtering.
+    Otherwise, omit the num_candidates parameter.
 
 9. filter_papers_by_nl_criteria — If the user specifies numeric or metadata constraints
    (e.g. date > 2022, citations ≥ 50, similarity_score > 0.8, specific authors, journal names, etc.),

--- a/paper_ranking/paper_ranker.py
+++ b/paper_ranking/paper_ranker.py
@@ -9,13 +9,15 @@ logger = logging.getLogger(__name__)
 
 
 @tool
-def get_best_papers(user_profile: str) -> list[dict]:
+def get_best_papers(user_profile: str, num_candidates: int = 10) -> list[dict]:
     """
     Tool Name: get_best_papers
-    Returns a list of recommended papers based on the user profile.
+    Returns a list of recommended papers based on the user profile. If the agent want to apply filtering, the agent will increase the
+    number of candidates to a higher number, e.g. 100 or 1000. To ensure that the agent can still return a reasonable number of papers, the default is set to 10.
 
     Args:
         user_profile (str): The user's input or research interests.
+        num_candidates (int): The number of candidate papers to return. Default is 10.
 
     Returns:
         List[Dict]: A list of paper metadata dictionaries.
@@ -31,7 +33,10 @@ def get_best_papers(user_profile: str) -> list[dict]:
         return []
 
     try:
-        paper_hashes = chroma_db.perform_similarity_search(10, embedded_profile)
+        if num_candidates != 10:
+            logger.info(f"Agent requested {num_candidates} candidates, which is different than the default of 10. This will allow for more filtering.")
+
+        paper_hashes = chroma_db.perform_similarity_search(num_candidates, embedded_profile)
 
     except Exception as e:
         logger.error(f"Error performing similarity search: {e}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ chromadb==1.0.12
 langchain-core==0.3.63
 langchain-openai==0.3.19
 langchain==0.3.25
-langgraph==0.5.0
+langgraph~=0.4.5
 openai==1.79.0
 psycopg2-binary==2.9.10
 pyalex==0.18


### PR DESCRIPTION
## Description

Fixed the problem where the agentic quality check (e.g. applying filter such as publication year) to the returned results leads to empty results being returned because we apply the filter only to the 10 best papers being returned. 

What we now do is that get_best_papers has an additional param, which the agent can modify to increase the number of papers returned when it wants to apply a filter in the next step. This ensures that instead of the top 10 we will retrieve the top 100 papers and filter them leading to much more stable results. 

Retrieving more papers makes the get_best_papers tool slower but I think it is worth it. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix

## How Has This Been Tested?

Run the code with tight filer constraints, such as from the year 2020 onwards to make sure you still see papers. Also check the logs to ensure there is a sufficient number of papers retrieved when filtering (e.g. 100) and filtered. 

## Reviewers

@Daniel @Aditi 
