### PR TITLE
Exisitng rojects use memory instead of agent call

### DIFF
--- a/app.py
+++ b/app.py
@@ -120,10 +120,10 @@ def get_recommendations():
         def generate():
             try:
                 if update_recommendations:
+                    # todo before calling the agent delete ALL papers for the project in paperprojects_table
                     for response_part in trigger_agent_show_thoughts(user_description + "project ID: " + project_id):
                         yield f"data: {json.dumps({'thought': response_part['thought']})}\n\n"
 
-                # todo update get_papers_for_project so that it doesnt return pubsub papers or define how the behaviour should be
                 recs_basic_data = get_papers_for_project(project_id)
                 recommendations = []
                 for rec in recs_basic_data:

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -68,7 +68,7 @@ function renderPubSubPapers(papers, container) {
               return alert('Error creating project');
             }
             const { projectId } = await res.json();
-            window.location.href = `/project/${projectId}`;
+            window.location.href = `/project/${projectId}?updateRecommendations=true`;
           });
 
 
@@ -125,8 +125,13 @@ function renderPubSubPapers(papers, container) {
             renderPubSubPapers(papers, container);
         }
 
+            const params= new URLSearchParams(window.location.search);
+            const updateRecommendations = params.get('updateRecommendations') === 'true';
             //5. Load rest of UI
-            loadProjectOverviewData(projectId, project.description);
+            loadProjectOverviewData(projectId, project.description, updateRecommendations);
+            if (updateRecommendations) {
+                history.replaceState({}, '', window.location.pathname);
+            }
 
         } else if (path === '/') {
             const createProjectBtn = document.getElementById('createProjectBtn');
@@ -265,7 +270,7 @@ function renderPubSubPapers(papers, container) {
         }
     }
 
-    function loadProjectOverviewData (projectId, projectDescription) {
+    function loadProjectOverviewData (projectId, projectDescription,  updateRecommendations = false) {
         const recommendationsContainer = document.getElementById('recommendationsContainer');
         const agentThoughtsContainer = document.getElementById('agentThoughtsContainer');
 
@@ -273,7 +278,7 @@ function renderPubSubPapers(papers, container) {
             agentThoughtsContainer.innerHTML = '<p>🧠 Agent is thinking...</p>';
             recommendationsContainer.innerHTML = '<p>⌛ Waiting for agent to provide recommendations...</p>';
 
-            fetchRecommendationsStream(projectId, projectDescription, agentThoughtsContainer, recommendationsContainer)
+            fetchRecommendationsStream(projectId, projectDescription, agentThoughtsContainer, recommendationsContainer, updateRecommendations)
                 .catch(error => {
                     console.error("Error fetching recommendations stream:", error);
                     agentThoughtsContainer.innerHTML += '<p>❌ Error communicating with the agent.</p>';
@@ -281,7 +286,7 @@ function renderPubSubPapers(papers, container) {
                 });
         }
 
-    async function fetchRecommendationsStream(projectId, projectDescription, thoughtsContainer, recommendationsContainer) {
+    async function fetchRecommendationsStream(projectId, projectDescription, thoughtsContainer, recommendationsContainer,  updateRecommendations = false) {
         console.log(`Starting to stream recommendations based on project description...`);
         thoughtsContainer.innerHTML = ''; // Clear for new thoughts
 
@@ -291,7 +296,7 @@ function renderPubSubPapers(papers, container) {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     projectId: projectId,
-                    update_recommendations : true //todo set this to true only if new project or if future 'refresh recommendations' button pressed
+                    update_recommendations : updateRecommendations //todo set this to true only if new project or if future 'refresh recommendations' button pressed
                 }),
             });
 


### PR DESCRIPTION
## Description

When entering an existing project, the recommendations are fetched from the database instead of having the agent create them 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Refactor (code cleanup, performance improvements, etc.)


## How Has This Been Tested?
Manual testing, create a project, get recommendations. Open project from project dashboard, wait a minute, see that you get recommendations with no agent thoughts as soon as pubsub loads
## Reviewers

@daniel-emrani @yawri 